### PR TITLE
Removed explicitly settings for read and write permission to 'Everyone' while changing sharing permission from user to app/global

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Bulk modify Splunk Knowledge Object's owners, permissions, apps, sharing and mov
   </tbody>
 </table>
 
-**NOTE: When you change sharing permission from `user` to `app` or `global` and if you do not provide `--readperm` and `--writeperm` parameter while changing permission then by default Read and Write Permission will be Everyone**
+**NOTE: When you change sharing permission from `user` to `app` or `global` and if you do not provide `--readperm` and `--writeperm` parameter while changing permission then by default it will inherit App read and write permission respectively.**
 
 ### How to use script (Examples)
 #### To check which knowledge objects you can move using `ko_change.py` script and for available script parameter you can use help as given below

--- a/ko_change.py
+++ b/ko_change.py
@@ -289,9 +289,7 @@ def change_permission(session_key, ko_name, old_owner, new_owner, file=None, new
                                 else:
                                     post_argument = {'sharing': new_sharing, 'owner': new_owner, 'perms.read': read_perm, 'perms.write': new_writeperm}
                             else:
-                                new_readperm = '*'
-                                new_writeperm = '*'
-                                post_argument = {'sharing': new_sharing, 'owner': new_owner, 'perms.read': new_readperm, 'perms.write': new_writeperm}
+                                post_argument = {'sharing': new_sharing, 'owner': new_owner}
                         else:
                             post_argument = {'sharing': new_sharing, 'owner': new_owner}
                     elif new_readperm:
@@ -325,9 +323,7 @@ def change_permission(session_key, ko_name, old_owner, new_owner, file=None, new
                             else:
                                 post_argument = {'sharing': new_sharing, 'owner': author_name, 'perms.read': read_perm, 'perms.write': new_writeperm}
                         else:
-                            new_readperm = '*'
-                            new_writeperm = '*'
-                            post_argument = {'sharing': new_sharing, 'owner': author_name, 'perms.read': new_readperm, 'perms.write': new_writeperm}
+                            post_argument = {'sharing': new_sharing, 'owner': author_name}
                     else:
                         post_argument = {'sharing': new_sharing, 'owner': author_name}
                 elif new_readperm:


### PR DESCRIPTION
Modified script to remove explicitly settings for read and write permission to 'Everyone' while chnging sharing permission of knowledge objects from 'user' to 'app' or 'global' level  and modifed README.md accordingly